### PR TITLE
Improve world memory module

### DIFF
--- a/campaign_manager.py
+++ b/campaign_manager.py
@@ -1,0 +1,295 @@
+"""Campaign management module for a TTRPG chatbot engine."""
+
+import json
+import os
+import uuid
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import Dict, Any, List
+
+
+def deep_update(orig: Dict[str, Any], new: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively update ``orig`` with values from ``new``."""
+    for key, value in new.items():
+        if (
+            isinstance(value, dict)
+            and isinstance(orig.get(key), dict)
+        ):
+            deep_update(orig[key], value)
+        else:
+            orig[key] = value
+    return orig
+
+# Base directories
+PLAYERS_DIR = os.path.join(os.getcwd(), "players")
+CAMPAIGNS_DIR = os.path.join(os.getcwd(), "campaigns")
+
+# Campaign data schema versioning
+VERSION = 1
+
+
+@dataclass
+class PlayerCharacter:
+    name: str
+    race: str
+    character_class: str
+    level: int = 1
+    background: str = ""
+    attributes: Dict[str, Any] | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class PlayerManager:
+    """Manage player character creation and storage."""
+
+    @staticmethod
+    def _player_file(name: str) -> str:
+        filename = f"{name.lower().replace(' ', '_')}.json"
+        return os.path.join(PLAYERS_DIR, filename)
+
+    def create_character(self) -> PlayerCharacter:
+        """Prompt user for character details and save the character."""
+        os.makedirs(PLAYERS_DIR, exist_ok=True)
+        name = input("Character name: ")
+        race = input("Race: ")
+        char_class = input("Class: ")
+        level = int(input("Level [1]: ") or 1)
+        background = input("Background: ")
+        attributes = {}
+        while True:
+            attr_name = input("Add attribute (or leave blank to finish): ")
+            if not attr_name:
+                break
+            attr_value = input(f"Value for {attr_name}: ")
+            try:
+                attr_value = int(attr_value)
+            except ValueError:
+                pass
+            attributes[attr_name] = attr_value
+
+        pc = PlayerCharacter(
+            name=name,
+            race=race,
+            character_class=char_class,
+            level=level,
+            background=background,
+            attributes=attributes,
+        )
+        with open(self._player_file(name), "w", encoding="utf-8") as f:
+            json.dump(pc.to_dict(), f, indent=2)
+        return pc
+
+    def load_character(self, name: str) -> PlayerCharacter | None:
+        path = self._player_file(name)
+        if not os.path.exists(path):
+            return None
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return PlayerCharacter(**data)
+
+
+class CampaignManager:
+    """Manage campaign world state."""
+
+    DEFAULT_FILES = [
+        "npcs.json",
+        "quests.json",
+        "items.json",
+        "events_log.json",
+        "world_state.json",
+    ]
+
+    def __init__(self, name: str):
+        self.name = name
+        self.path = os.path.join(CAMPAIGNS_DIR, name)
+        os.makedirs(self.path, exist_ok=True)
+        # ensure versioning file
+        version_file = os.path.join(self.path, "version.json")
+        if not os.path.exists(version_file):
+            with open(version_file, "w", encoding="utf-8") as fp:
+                json.dump({"version": VERSION}, fp, indent=2)
+
+        # create default data files
+        for f in self.DEFAULT_FILES:
+            file_path = os.path.join(self.path, f)
+            if not os.path.exists(file_path):
+                with open(file_path, "w", encoding="utf-8") as fp:
+                    if f == "quests.json":
+                        json.dump({"active": {}, "completed": {}, "missed": {}}, fp, indent=2)
+                    else:
+                        json.dump({}, fp, indent=2)
+
+        # ensure players directory inside each campaign
+        os.makedirs(os.path.join(self.path, "players"), exist_ok=True)
+
+    def _load_json(self, filename: str) -> Dict[str, Any]:
+        path = os.path.join(self.path, filename)
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def _save_json(self, filename: str, data: Dict[str, Any]):
+        path = os.path.join(self.path, filename)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+    # ------------------------------------------------------
+    # Player state management
+    # ------------------------------------------------------
+    def _player_state_file(self, player_name: str) -> str:
+        """Return path to a player's dynamic state file."""
+        filename = f"{player_name.lower().replace(' ', '_')}.json"
+        return os.path.join(self.path, "players", filename)
+
+    def initialize_player_state(self, player_name: str) -> None:
+        """Create a default player state file if it doesn't exist."""
+        file_path = self._player_state_file(player_name)
+        if not os.path.exists(file_path):
+            default_state = {"gold": 0, "inventory": [], "quests": []}
+            with open(file_path, "w", encoding="utf-8") as f:
+                json.dump(default_state, f, indent=2)
+
+    def update_player_state(self, player_name: str, updates: Dict[str, Any]):
+        """Update dynamic player state with provided values."""
+        self.initialize_player_state(player_name)
+        file_path = self._player_state_file(player_name)
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        deep_update(data, updates)
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+    # ------------------------------------------------------
+    # Quest management helpers
+    # ------------------------------------------------------
+    def _load_quests(self) -> Dict[str, Dict[str, Any]]:
+        quests = self._load_json("quests.json")
+        if not all(k in quests for k in ("active", "completed", "missed")):
+            quests = {"active": {}, "completed": {}, "missed": {}}
+        return quests
+
+    def _save_quests(self, quests: Dict[str, Dict[str, Any]]):
+        self._save_json("quests.json", quests)
+
+    def add_npc(self, npc_data: Dict[str, Any]) -> str:
+        """Add a new NPC to the campaign.
+
+        ``npc_data`` may optionally include a ``relationships`` mapping. Example::
+
+            {
+                "name": "Ari", "race": "elf",
+                "relationships": {
+                    "Damian": {"trust": 80, "notes": "He defended her honor."}
+                }
+            }
+        """
+        npcs = self._load_json("npcs.json")
+        npc_id = str(uuid.uuid4())
+        npc_data.setdefault("timestamp", datetime.utcnow().isoformat())
+        npcs[npc_id] = npc_data
+        self._save_json("npcs.json", npcs)
+        return npc_id
+
+    def update_npc(self, npc_id: str, updates: Dict[str, Any]) -> bool:
+        """Update an existing NPC entry using deep merging."""
+        npcs = self._load_json("npcs.json")
+        if npc_id not in npcs:
+            return False
+        deep_update(npcs[npc_id], updates)
+        self._save_json("npcs.json", npcs)
+        return True
+
+    def add_quest(self, quest_data: Dict[str, Any]) -> str:
+        quests = self._load_quests()
+        quest_id = str(uuid.uuid4())
+        quest_data["timestamp"] = datetime.utcnow().isoformat()
+        quests["active"][quest_id] = quest_data
+        self._save_quests(quests)
+        return quest_id
+
+    def complete_quest(self, quest_id: str, player_name: str | None = None) -> bool:
+        """Move quest from active or missed to completed.
+
+        If ``player_name`` is given, append the completion info to that
+        player's state. This can later be expanded for richer tracking.
+        """
+        quests = self._load_quests()
+        for status in ("active", "missed"):
+            if quest_id in quests.get(status, {}):
+                quests["completed"][quest_id] = quests[status].pop(quest_id)
+                self._save_quests(quests)
+                if player_name:
+                    # append quest result to player's history
+                    path = self._player_state_file(player_name)
+                    self.initialize_player_state(player_name)
+                    with open(path, "r", encoding="utf-8") as f:
+                        state = json.load(f)
+                    state.setdefault("quests", [])
+                    state["quests"].append(
+                        {
+                            "id": quest_id,
+                            "status": "completed",
+                            "timestamp": datetime.utcnow().isoformat(),
+                        }
+                    )
+                    with open(path, "w", encoding="utf-8") as f:
+                        json.dump(state, f, indent=2)
+                return True
+        return False
+
+    def miss_quest(self, quest_id: str) -> bool:
+        """Move quest from active to missed."""
+        quests = self._load_quests()
+        if quest_id in quests.get("active", {}):
+            quests["missed"][quest_id] = quests["active"].pop(quest_id)
+            self._save_quests(quests)
+            return True
+        return False
+
+    def log_event(self, event: str):
+        events = self._load_json("events_log.json")
+        event_id = str(uuid.uuid4())
+        events[event_id] = {
+            "description": event,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        self._save_json("events_log.json", events)
+        return event_id
+
+    def update_world_state(self, updates: Dict[str, Any]):
+        state = self._load_json("world_state.json")
+        state.update(updates)
+        self._save_json("world_state.json", state)
+
+    def add_item(self, item_data: Dict[str, Any]) -> str:
+        items = self._load_json("items.json")
+        item_id = str(uuid.uuid4())
+        item_data["timestamp"] = datetime.utcnow().isoformat()
+        items[item_id] = item_data
+        self._save_json("items.json", items)
+        return item_id
+
+    def search_npcs(self, query: str) -> List[Dict[str, Any]]:
+        npcs = self._load_json("npcs.json")
+        return [v for v in npcs.values() if query.lower() in str(v).lower()]
+
+    def search_items(self, query: str) -> List[Dict[str, Any]]:
+        items = self._load_json("items.json")
+        return [v for v in items.values() if query.lower() in str(v).lower()]
+
+    def search_events(self, query: str) -> List[Dict[str, Any]]:
+        """Return events containing the query string."""
+        events = self._load_json("events_log.json")
+        return [
+            ev
+            for ev in events.values()
+            if query.lower() in str(ev.get("description", "")).lower()
+        ]
+
+
+# Placeholder for future web search capability
+
+def search_web(query: str) -> str:
+    """Placeholder for future web search implementation."""
+    return ""

--- a/prompt_builder.py
+++ b/prompt_builder.py
@@ -1,0 +1,95 @@
+"""Utilities to build conversation prompts for the TTRPG chatbot."""
+
+from typing import Any, Dict, List
+
+
+def summarize_player(player_data: Dict[str, Any]) -> str:
+    """Return a short summary describing the player."""
+    name = player_data.get("name", "Unknown")
+    race = player_data.get("race", "unknown race")
+    char_class = player_data.get("character_class", "adventurer")
+    level = player_data.get("level", 1)
+    background = player_data.get("background", "")
+    gold = player_data.get("gold", player_data.get("state", {}).get("gold", 0))
+    inventory = player_data.get("inventory", [])
+    if isinstance(inventory, dict):
+        inventory = list(inventory.values())
+    items = ", ".join(str(i) for i in inventory[:3])
+    if len(inventory) > 3:
+        items += f", and {len(inventory) - 3} more"
+    parts = [
+        f"{name} is a level {level} {race} {char_class}",
+    ]
+    if background:
+        parts.append(f"from {background}")
+    summary = " ".join(parts) + "."
+    if gold or items:
+        summary += f" They have {gold} gold"
+        if items:
+            summary += f" and carry {items}"
+        summary += "."
+    return summary
+
+
+def summarize_campaign(campaign_data: Dict[str, Any]) -> str:
+    """Return a concise summary of the campaign."""
+    quests = campaign_data.get("quests", {})
+    active = len(quests.get("active", {}))
+    completed = len(quests.get("completed", {}))
+    npc_count = len(campaign_data.get("npcs", {}))
+    events = campaign_data.get("events", {})
+    last_event = ""
+    if events:
+        last_key = sorted(events.keys())[-1]
+        last_event = events[last_key].get("description", "")
+    summary = (
+        f"The party knows {npc_count} NPCs. "
+        f"There are {active} active quests and {completed} completed."
+    )
+    if last_event:
+        summary += f" Recent event: {last_event}."
+    return summary
+
+
+def summarize_world(world_memory: List[Dict[str, Any]]) -> str:
+    """Summarize notable world memory entries."""
+    if not world_memory:
+        return "No notable world facts are recorded yet."
+    names = [entry.get("name") for entry in world_memory[:5] if entry.get("name")]
+    listed = ", ".join(names)
+    summary = f"Notable entries include: {listed}."
+    return summary
+
+
+def truncate_history(history: List[str], limit: int = 15) -> List[str]:
+    """Return only the last ``limit`` lines of conversation history."""
+    return history[-limit:]
+
+
+def build_prompt(
+    player_name: str,
+    player_data: Dict[str, Any],
+    campaign_data: Dict[str, Any],
+    world_memory: List[Dict[str, Any]],
+    conversation_history: List[str],
+    current_input: str,
+) -> str:
+    """Build a text prompt for the chatbot."""
+    player_summary = summarize_player(player_data)
+    campaign_summary = summarize_campaign(campaign_data)
+    world_summary = summarize_world(world_memory)
+    history = truncate_history(conversation_history)
+
+    lines = [
+        f"You are the narrator guiding {player_name} on their adventures.",
+        "\n### Player Info",
+        player_summary,
+        "\n### Campaign",
+        campaign_summary,
+        "\n### World Memory",
+        world_summary,
+        "\n### Recent Conversation",
+        *history,
+        f"Player: {current_input}",
+    ]
+    return "\n".join(lines)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,105 @@
+import os
+import json
+import streamlit as st
+
+from campaign_manager import CampaignManager, PlayerManager
+from world_memory import WorldMemoryManager
+from prompt_builder import build_prompt
+
+
+def get_response(prompt: str) -> str:
+    """Return a response from OpenAI's chat API."""
+    import openai
+
+    api_key = st.secrets.get("openai_api_key") or os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        return "Missing OpenAI API key."
+    openai.api_key = api_key
+    resp = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return resp.choices[0].message["content"].strip()
+
+
+def initialize_state(campaign_name: str, player_name: str):
+    """Load managers and ensure player state exists."""
+    cm = CampaignManager(campaign_name)
+    cm.initialize_player_state(player_name)
+    pm = PlayerManager()
+    character = pm.load_character(player_name)
+    if character is None:
+        character = pm.create_character()
+    wm = WorldMemoryManager(campaign_name)
+    st.session_state.campaign_manager = cm
+    st.session_state.player_manager = pm
+    st.session_state.world_memory = wm
+    st.session_state.character = character
+
+
+def load_player_state(cm: CampaignManager, player_name: str) -> dict:
+    path = cm._player_state_file(player_name)
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {"gold": 0, "inventory": [], "quests": []}
+
+
+def load_campaign_data(cm: CampaignManager) -> dict:
+    return {
+        "npcs": cm._load_json("npcs.json"),
+        "quests": cm._load_json("quests.json"),
+        "items": cm._load_json("items.json"),
+        "events": cm._load_json("events_log.json"),
+    }
+
+
+st.title("TTRPG Chatbot")
+
+campaign_name = st.text_input("Campaign Name", st.session_state.get("campaign_name", "demo"))
+player_name = st.text_input("Player Name", st.session_state.get("player_name", ""))
+
+if campaign_name and player_name and "campaign_manager" not in st.session_state:
+    initialize_state(campaign_name, player_name)
+    st.session_state.campaign_name = campaign_name
+    st.session_state.player_name = player_name
+
+if "history" not in st.session_state:
+    st.session_state.history = []
+
+user_message = st.text_input("Message", "")
+if st.button("Send") and user_message:
+    st.session_state.history.append(f"Player: {user_message}")
+    cm = st.session_state.campaign_manager
+    wm = st.session_state.world_memory
+
+    player_state = load_player_state(cm, player_name)
+    character = st.session_state.character.to_dict() if hasattr(st.session_state.character, 'to_dict') else st.session_state.character
+    player_data = {**character, **player_state}
+
+    campaign_data = load_campaign_data(cm)
+    world_mem = list(wm._load().values())
+
+    prompt = build_prompt(
+        player_name,
+        player_data,
+        campaign_data,
+        world_mem,
+        st.session_state.history,
+        user_message,
+    )
+    response = get_response(prompt)
+    st.session_state.history.append(f"Narrator: {response}")
+
+for line in st.session_state.history:
+    st.write(line)
+
+st.header("Player Stats")
+if "campaign_manager" in st.session_state:
+    ps = load_player_state(st.session_state.campaign_manager, player_name)
+    st.json(ps)
+
+st.header("World Memory Preview")
+if "world_memory" in st.session_state:
+    wm_data = list(st.session_state.world_memory._load().values())[:5]
+    st.json(wm_data)

--- a/world_memory.py
+++ b/world_memory.py
@@ -1,0 +1,94 @@
+"""World memory management for a TTRPG campaign engine."""
+
+import json
+import os
+import uuid
+from datetime import datetime
+from typing import Dict, Any, List, Optional
+
+# Allowed entity types for validation
+ALLOWED_TYPES = ["city", "faction", "business", "monster", "event"]
+
+from campaign_manager import CAMPAIGNS_DIR, deep_update
+
+
+class WorldMemoryManager:
+    """Handle persistent world memory for a specific campaign."""
+
+    def __init__(self, campaign_name: str) -> None:
+        self.campaign_name = campaign_name
+        self.path = os.path.join(CAMPAIGNS_DIR, campaign_name)
+        os.makedirs(self.path, exist_ok=True)
+        self.file_path = os.path.join(self.path, "world_memory.json")
+        if not os.path.exists(self.file_path):
+            with open(self.file_path, "w", encoding="utf-8") as f:
+                json.dump({}, f, indent=2)
+
+    def _load(self) -> Dict[str, Any]:
+        with open(self.file_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def _save(self, data: Dict[str, Any]) -> None:
+        with open(self.file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+    def add_memory_entry(self, entry: Dict[str, Any]) -> str:
+        """Add a new memory entry and return its ID."""
+        data = self._load()
+
+        required = ["type", "name"]
+        if any(not entry.get(k) for k in required):
+            raise ValueError("Missing required fields: type and name")
+
+        if entry["type"] not in ALLOWED_TYPES:
+            raise ValueError(f"Invalid type: {entry['type']}")
+
+        entry_id = str(uuid.uuid4())
+        entry_obj = {
+            "id": entry_id,
+            "type": entry.get("type", ""),
+            "name": entry.get("name", ""),
+            "description": entry.get("description", ""),
+            "tags": entry.get("tags", []),
+            "related_to": entry.get("related_to", []),
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        data[entry_id] = entry_obj
+        self._save(data)
+        return entry_id
+
+    def search_memory(self, query: str, type_filter: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Search memory entries by keyword and optional type."""
+        data = self._load()
+        results: List[Dict[str, Any]] = []
+        for entry in data.values():
+            if type_filter and entry.get("type") != type_filter:
+                continue
+            haystack = json.dumps(entry).lower()
+            if query.lower() in haystack:
+                results.append(entry)
+        return results
+
+    def update_memory_entry(self, entry_id: str, updates: Dict[str, Any]) -> bool:
+        """Update a memory entry using deep merging."""
+        data = self._load()
+        if entry_id not in data:
+            return False
+        deep_update(data[entry_id], updates)
+        self._save(data)
+        return True
+
+    def link_entities(self, entry_id: str, related_id: str, bidirectional: bool = False) -> bool:
+        """Link two memory entities by ID."""
+        data = self._load()
+        if entry_id not in data or related_id not in data:
+            return False
+        related = data[entry_id].setdefault("related_to", [])
+        if related_id not in related:
+            related.append(related_id)
+        if bidirectional:
+            back = data[related_id].setdefault("related_to", [])
+            if entry_id not in back:
+                back.append(entry_id)
+        self._save(data)
+        return True


### PR DESCRIPTION
## Summary
- validate required fields and allowed types when adding memory entries
- rename variable in `link_entities` and add optional bidirectional linking
- add utilities for building prompts from player, campaign, and world data
- add a basic Streamlit chatbot app using campaign helpers

## Testing
- `python -m py_compile campaign_manager.py world_memory.py prompt_builder.py streamlit_app.py`
- `python - <<'EOF'
import types, sys
class DummyState(dict):
    __getattr__ = dict.get
    __setattr__ = dict.__setitem__

session_state = DummyState()
streamlit = types.SimpleNamespace(
    secrets={},
    session_state=session_state,
    title=lambda *a, **k: None,
    text_input=lambda *a, **k: '',
    button=lambda *a, **k: False,
    header=lambda *a, **k: None,
    write=lambda *a, **k: None,
    json=lambda *a, **k: None,
)
sys.modules['streamlit'] = streamlit
import campaign_manager as cm, world_memory as wm, prompt_builder as pb, streamlit_app as sa
print('loaded', cm.CampaignManager.__name__, wm.WorldMemoryManager.__name__, pb.build_prompt.__name__, sa.get_response.__name__)
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68662ce86ac483228c6b9dd0f5b89841