### PR TITLE
Add campaign management utilities

### DIFF
--- a/campaign_manager.py
+++ b/campaign_manager.py
@@ -3,6 +3,7 @@
 import json
 import os
 import uuid
+import shutil
 from dataclasses import dataclass, asdict
 from datetime import datetime
 from typing import Dict, Any, List
@@ -26,6 +27,26 @@ CAMPAIGNS_DIR = os.path.join(os.getcwd(), "campaigns")
 
 # Campaign data schema versioning
 VERSION = 1
+
+
+def list_campaigns() -> List[str]:
+    """Return a list of available campaign names."""
+    if not os.path.exists(CAMPAIGNS_DIR):
+        return []
+    return [
+        name
+        for name in os.listdir(CAMPAIGNS_DIR)
+        if os.path.isdir(os.path.join(CAMPAIGNS_DIR, name))
+    ]
+
+
+def delete_campaign(name: str) -> bool:
+    """Delete an entire campaign directory."""
+    path = os.path.join(CAMPAIGNS_DIR, name)
+    if not os.path.isdir(path):
+        return False
+    shutil.rmtree(path)
+    return True
 
 
 @dataclass

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,6 +6,8 @@ from campaign_manager import (
     CampaignManager,
     PlayerManager,
     PlayerCharacter,
+    list_campaigns,
+    delete_campaign,
 )
 from world_memory import WorldMemoryManager, ALLOWED_TYPES
 from prompt_builder import build_prompt
@@ -108,7 +110,39 @@ def load_campaign_data(cm: CampaignManager) -> dict:
 
 st.title("TTRPG Chatbot")
 
-campaign_name = st.text_input("Campaign Name", st.session_state.get("campaign_name", "demo"))
+with st.expander("Manage Campaigns"):
+    campaigns = list_campaigns()
+    if campaigns:
+        selected = st.selectbox("Existing Campaigns", campaigns, key="campaign_select")
+        col1, col2 = st.columns(2)
+        with col1:
+            if st.button("Load", key="load_campaign_btn"):
+                st.session_state.campaign_name = selected
+                for key in ("campaign_manager", "player_manager", "world_memory"):
+                    st.session_state.pop(key, None)
+                st.session_state.history = []
+                if st.session_state.get("player_name"):
+                    initialize_state(selected, st.session_state["player_name"])
+                st.experimental_rerun()
+        with col2:
+            if st.button("Delete", key="delete_campaign_btn"):
+                delete_campaign(selected)
+                if st.session_state.get("campaign_name") == selected:
+                    for key in (
+                        "campaign_manager",
+                        "player_manager",
+                        "world_memory",
+                        "campaign_name",
+                    ):
+                        st.session_state.pop(key, None)
+                st.experimental_rerun()
+    else:
+        st.write("No campaigns found.")
+
+campaign_name = st.text_input(
+    "Campaign Name",
+    st.session_state.get("campaign_name", "demo"),
+)
 player_name = st.text_input("Player Name", st.session_state.get("player_name", ""))
 
 if campaign_name and player_name and "campaign_manager" not in st.session_state:
@@ -196,5 +230,5 @@ if "world_memory" in st.session_state:
                     )
                     st.experimental_rerun()
                 except ValueError as e:
-    st.error(str(e))
+                    st.error(str(e))
 


### PR DESCRIPTION
## Summary
- allow listing and deleting campaigns in `campaign_manager`
- integrate campaign selection/deletion in Streamlit UI
- fix indentation error

## Testing
- `python -m py_compile campaign_manager.py streamlit_app.py world_memory.py prompt_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_686935f8071483229f046ffa6c04aec9