### PR TITLE
Add tests for JournalManager

### DIFF
--- a/journal_manager.py
+++ b/journal_manager.py
@@ -63,9 +63,13 @@ class JournalManager:
             self._save(data)
 
     def update_gold(self, delta: int) -> None:
-        """Change gold by ``delta`` which may be positive or negative."""
+        """Change gold by ``delta`` which may be positive or negative.
+
+        The resulting gold value will never go below zero.
+        """
         data = self._load()
-        data["gold"] = data.get("gold", 0) + int(delta)
+        new_total = data.get("gold", 0) + int(delta)
+        data["gold"] = max(new_total, 0)
         self._save(data)
 
     def add_gold(self, amount: int) -> None:

--- a/tests/test_journal_manager.py
+++ b/tests/test_journal_manager.py
@@ -1,0 +1,42 @@
+import json
+import journal_manager
+import campaign_manager
+
+import pytest
+
+
+@pytest.fixture()
+def jm(tmp_path, monkeypatch):
+    camp_dir = tmp_path / "campaigns"
+    monkeypatch.setattr(campaign_manager, "CAMPAIGNS_DIR", str(camp_dir), raising=False)
+    monkeypatch.setattr(journal_manager, "CAMPAIGNS_DIR", str(camp_dir), raising=False)
+    return journal_manager.JournalManager("test", "Alice")
+
+
+def load_journal(jm):
+    with open(jm.path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_inventory_updates(jm):
+    jm.add_item("Sword")
+    data = load_journal(jm)
+    assert "Sword" in data.get("inventory", [])
+
+    jm.remove_item("Sword")
+    data = load_journal(jm)
+    assert "Sword" not in data.get("inventory", [])
+
+
+def test_gold_never_negative(jm):
+    jm.add_gold(10)
+    data = load_journal(jm)
+    assert data["gold"] == 10
+
+    jm.remove_gold(15)
+    data = load_journal(jm)
+    assert data["gold"] == 0
+
+    jm.update_gold(-5)
+    data = load_journal(jm)
+    assert data["gold"] == 0


### PR DESCRIPTION
## Summary
- clamp gold totals at zero in JournalManager
- add pytest tests covering journal inventory and gold logic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a74869ab48322978f5ef9a05d559b