### PR TITLE
Ensure tests clean: timezone-aware timestamps

### DIFF
--- a/campaign_manager.py
+++ b/campaign_manager.py
@@ -5,7 +5,7 @@ import os
 import uuid
 import shutil
 from dataclasses import dataclass, asdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, List
 
 
@@ -214,7 +214,7 @@ class CampaignManager:
         """
         npcs = self._load_json("npcs.json")
         npc_id = str(uuid.uuid4())
-        npc_data.setdefault("timestamp", datetime.utcnow().isoformat())
+        npc_data.setdefault("timestamp", datetime.now(timezone.utc).isoformat())
         npcs[npc_id] = npc_data
         self._save_json("npcs.json", npcs)
         return npc_id
@@ -231,7 +231,7 @@ class CampaignManager:
     def add_quest(self, quest_data: Dict[str, Any]) -> str:
         quests = self._load_quests()
         quest_id = str(uuid.uuid4())
-        quest_data["timestamp"] = datetime.utcnow().isoformat()
+        quest_data["timestamp"] = datetime.now(timezone.utc).isoformat()
         quests["active"][quest_id] = quest_data
         self._save_quests(quests)
         return quest_id
@@ -258,7 +258,7 @@ class CampaignManager:
                         {
                             "id": quest_id,
                             "status": "completed",
-                            "timestamp": datetime.utcnow().isoformat(),
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
                         }
                     )
                     with open(path, "w", encoding="utf-8") as f:
@@ -280,7 +280,7 @@ class CampaignManager:
         event_id = str(uuid.uuid4())
         events[event_id] = {
             "description": event,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         self._save_json("events_log.json", events)
         return event_id
@@ -293,7 +293,7 @@ class CampaignManager:
     def add_item(self, item_data: Dict[str, Any]) -> str:
         items = self._load_json("items.json")
         item_id = str(uuid.uuid4())
-        item_data["timestamp"] = datetime.utcnow().isoformat()
+        item_data["timestamp"] = datetime.now(timezone.utc).isoformat()
         items[item_id] = item_data
         self._save_json("items.json", items)
         return item_id

--- a/journal_manager.py
+++ b/journal_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from campaign_manager import CAMPAIGNS_DIR
@@ -129,7 +129,7 @@ class JournalManager:
             {
                 "title": title or "",
                 "description": description,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             }
         )
         self._save(data)

--- a/world_memory.py
+++ b/world_memory.py
@@ -3,7 +3,7 @@
 import json
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
 
 # Allowed entity types for validation
@@ -51,7 +51,7 @@ class WorldMemoryManager:
             "description": entry.get("description", ""),
             "tags": entry.get("tags", []),
             "related_to": entry.get("related_to", []),
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         data[entry_id] = entry_obj
         self._save(data)


### PR DESCRIPTION
## Summary
- address deprecation warnings by using timezone-aware timestamps
- clean up campaign, journal and world memory modules

## Testing
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_686a9361bfb88322997076c5844e7876