### PR TITLE
Implement story arc manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,11 @@ Execute the test suite with:
 ```bash
 pytest
 ```
+
+## Story Arc Features
+
+Campaigns now automatically create a hidden villain entry and DM event log. Use
+``ArcManager`` to inspect or advance the antagonist's agenda without revealing
+details to the player. ``WorldMemoryManager`` accepts ``hidden=True`` to store
+DM-only information and supports ``villain`` and ``plot`` entity types. Quest
+titles must be unique when added via ``CampaignManager.add_quest``.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .arc_manager import ArcManager

--- a/arc_manager.py
+++ b/arc_manager.py
@@ -1,0 +1,48 @@
+"""Story arc management for campaigns."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .campaign_manager import CampaignManager
+from .world_memory import WorldMemoryManager
+
+DEFAULT_VILLAIN = {
+    "type": "villain",
+    "name": "The Shadow Lord",
+    "description": "A mysterious foe seeking dominion over the realm.",
+    "tags": ["arc"],
+}
+
+
+class ArcManager:
+    """Manage campaign-level story arcs and villains."""
+
+    def __init__(self, campaign_name: str) -> None:
+        self.campaign_name = campaign_name
+        self.campaign = CampaignManager(campaign_name)
+        self.dm_memory = WorldMemoryManager(campaign_name, hidden=True)
+        self.villain_id = self._ensure_villain()
+
+    # --------------------------------------------------------------
+    # Villain helpers
+    # --------------------------------------------------------------
+    def _ensure_villain(self) -> str:
+        """Return the existing villain ID or create a default villain."""
+        villains = self.dm_memory.search_memory("", type_filter="villain")
+        if villains:
+            return villains[0]["id"]
+        return self.dm_memory.add_memory_entry(DEFAULT_VILLAIN)
+
+    def get_villain(self) -> Dict[str, Any]:
+        """Return the current villain entry."""
+        results = self.dm_memory.search_memory("", type_filter="villain")
+        return results[0] if results else {}
+
+    def progress_villain(self, description: str) -> str:
+        """Record the villain's latest move in the DM event log."""
+        self.campaign.log_event(description, hidden=True)
+        villain = self.get_villain()
+        if villain:
+            self.dm_memory.update_memory_entry(villain["id"], {"description": description})
+        return description

--- a/tests/test_world_memory.py
+++ b/tests/test_world_memory.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+import sys
+import BlackFeather.campaign_manager as campaign_manager
+sys.modules.setdefault("campaign_manager", campaign_manager)
+import BlackFeather.world_memory as world_memory
+sys.modules.setdefault("world_memory", world_memory)
+from BlackFeather.world_memory import WorldMemoryManager
+
+
+def test_hidden_memory(tmp_path, monkeypatch):
+    monkeypatch.setattr(campaign_manager, "CAMPAIGNS_DIR", tmp_path)
+    monkeypatch.setattr(world_memory, "CAMPAIGNS_DIR", tmp_path)
+    wm = WorldMemoryManager("Arc Test", hidden=True)
+    dm_file = Path(tmp_path) / "Arc Test" / "world_memory_dm.json"
+    assert dm_file.exists()
+
+    entry_id = wm.add_memory_entry({"type": "villain", "name": "Zara"})
+    data = json.loads(dm_file.read_text())
+    assert entry_id in data

--- a/world_memory.py
+++ b/world_memory.py
@@ -7,19 +7,30 @@ from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
 
 # Allowed entity types for validation
-ALLOWED_TYPES = ["city", "faction", "business", "monster", "event"]
+# ``villain`` and ``plot`` are used internally for DM information.
+ALLOWED_TYPES = [
+    "city",
+    "faction",
+    "business",
+    "monster",
+    "event",
+    "villain",
+    "plot",
+]
 
-from campaign_manager import CAMPAIGNS_DIR, deep_update
+from .campaign_manager import CAMPAIGNS_DIR, deep_update
 
 
 class WorldMemoryManager:
     """Handle persistent world memory for a specific campaign."""
 
-    def __init__(self, campaign_name: str) -> None:
+    def __init__(self, campaign_name: str, hidden: bool = False) -> None:
         self.campaign_name = campaign_name
+        self.hidden = hidden
         self.path = os.path.join(CAMPAIGNS_DIR, campaign_name)
         os.makedirs(self.path, exist_ok=True)
-        self.file_path = os.path.join(self.path, "world_memory.json")
+        filename = "world_memory_dm.json" if hidden else "world_memory.json"
+        self.file_path = os.path.join(self.path, filename)
         if not os.path.exists(self.file_path):
             with open(self.file_path, "w", encoding="utf-8") as f:
                 json.dump({}, f, indent=2)


### PR DESCRIPTION
## Summary
- manage secret villain data through a new `ArcManager`
- extend `WorldMemoryManager` with `villain` and `plot` types and allow hidden files
- track DM-only events in `CampaignManager`
- enforce unique quest titles
- document new story arc features
- add tests for hidden world memory

## Testing
- `pytest -q BlackFeather/tests`

------
https://chatgpt.com/codex/tasks/task_e_686b8189b2248322b0f4e3e3c98705cb