### PR TITLE
feat: configurable chat model and prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ Each campaign lives in the `campaigns/` folder and stores its own NPCs, quests, 
    streamlit run streamlit_app.py
    ```
 
+### Configuration
+
+You can control which chat model is used and supply a custom system prompt
+through environment variables or a `config.json` file in the project root.
+Supported keys are:
+
+- `CHAT_MODEL` / `chat_model` – OpenAI model name (default `gpt-3.5-turbo`)
+- `SYSTEM_PROMPT` / `system_prompt` – text for the system prompt
+
+Environment variables override values in `config.json`. Example:
+
+```json
+{
+  "chat_model": "gpt-4",
+  "system_prompt": "You are the narrator guiding the player."
+}
+```
+
 ## Running Tests
 
 Execute the test suite with:

--- a/config.py
+++ b/config.py
@@ -1,0 +1,32 @@
+import json
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class Config:
+    """Application configuration."""
+
+    chat_model: str = "gpt-3.5-turbo"
+    system_prompt: str = ""
+
+
+def load_config(path: str = "config.json") -> Config:
+    """Load configuration from a JSON file and environment variables."""
+    cfg = Config()
+    data = {}
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception:
+            pass
+    cfg.chat_model = os.getenv("CHAT_MODEL", data.get("chat_model", cfg.chat_model))
+    cfg.system_prompt = os.getenv(
+        "SYSTEM_PROMPT", data.get("system_prompt", cfg.system_prompt)
+    )
+    return cfg
+
+
+# Load default config at import time
+CONFIG = load_config()

--- a/prompt_builder.py
+++ b/prompt_builder.py
@@ -94,6 +94,7 @@ def build_prompt(
     world_memory: List[Dict[str, Any]],
     conversation_history: List[str],
     current_input: str,
+    system_prompt: str | None = None,
 ) -> str:
     """Build a text prompt for the chatbot."""
     player_summary = summarize_player(player_data)
@@ -101,8 +102,9 @@ def build_prompt(
     world_summary = summarize_world(world_memory)
     history = truncate_history(conversation_history)
 
+    intro = system_prompt or f"You are the narrator guiding {player_name} on their adventures."
     lines = [
-        f"You are the narrator guiding {player_name} on their adventures.",
+        intro,
         "\n### Player Info",
         player_summary,
         "\n### Campaign",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,6 +2,8 @@ import os
 import json
 import streamlit as st
 
+from config import CONFIG
+
 from campaign_manager import (
     CampaignManager,
     PlayerManager,
@@ -36,9 +38,13 @@ def get_response(prompt: str) -> str:
         import openai
 
         openai.api_key = api_key
+        messages = []
+        if CONFIG.system_prompt:
+            messages.append({"role": "system", "content": CONFIG.system_prompt})
+        messages.append({"role": "user", "content": prompt})
         resp = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": prompt}],
+            model=CONFIG.chat_model,
+            messages=messages,
         )
         return resp.choices[0].message["content"].strip()
     except Exception as e:  # pragma: no cover - depends on external API
@@ -202,6 +208,7 @@ if st.button("Send") and st.session_state.user_message:
         world_mem,
         st.session_state.history,
         msg_to_send,
+        CONFIG.system_prompt,
     )
     response = get_response(prompt)
     st.session_state.history.append(f"Narrator: {response}")


### PR DESCRIPTION
## Summary
- add config module to read environment variables or `config.json`
- support custom system prompt and model in `streamlit_app`
- expose optional system prompt in `build_prompt`
- document configuration options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686baa458a5c8322a3063b8024214629