### PR TITLE
Implement search and cli utilities

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -2,9 +2,9 @@
 
 Below are some ideas for improving the BlackFeather project:
 
-- Expand test coverage to include CampaignManager and WorldMemoryManager.
-- Move Streamlit UI components into smaller modules for easier maintenance.
-- Add configuration options for the chat model and system prompts.
-- Document how to deploy the app to common hosting platforms.
+- Refactor the Streamlit UI into smaller components.
+- Add more automated tests around the Streamlit interface.
+- Explore richer world memory editing features.
+- Consider integrating real web search results.
 
 Contributions and suggestions are welcome!

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ Launch the interface with:
 streamlit run streamlit_app.py
 ```
 
+### Configuration
+
+The behaviour of the chatbot can be tuned via a `config.json` file or
+environment variables. Available settings include:
+
+- `chat_model` – OpenAI model name
+- `system_prompt` – default narrator prompt
+- `temperature` – sampling temperature (default `0.7`)
+- `max_tokens` – response length limit (default `256`)
+
+Environment variables of the same name take precedence over the file values.
+
 ## Currency Tracking
 
 The Streamlit interface now includes an **Update Currency** panel under the
@@ -75,6 +87,17 @@ Execute the test suite with:
 
 ```bash
 pytest
+```
+
+## Command Line Utilities
+
+Basic campaign management can be performed without the UI using
+``cli.py``:
+
+```bash
+python cli.py list
+python cli.py create my_campaign
+python cli.py delete my_campaign
 ```
 
 ## Story Arc Features

--- a/campaign_manager.py
+++ b/campaign_manager.py
@@ -331,8 +331,23 @@ class CampaignManager:
         ]
 
 
-# Placeholder for future web search capability
+# ----------------------------------------------------------------------
+# Web search helper
+# ----------------------------------------------------------------------
 
 def search_web(query: str) -> str:
-    """Placeholder for future web search implementation."""
-    return ""
+    """Return a brief web search result for the query.
+
+    This uses ``duckduckgo_search`` if available and falls back to a
+    simple placeholder when network access is restricted.
+    """
+    try:  # pragma: no cover - network may be blocked
+        from duckduckgo_search import DDGS
+
+        with DDGS() as ddgs:
+            results = ddgs.text(query, max_results=1)
+        if results:
+            return results[0]["body"]
+    except Exception:
+        pass
+    return f"Web search is unavailable for '{query}'."

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,34 @@
+import argparse
+from campaign_manager import CampaignManager, delete_campaign, list_campaigns
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Manage campaigns")
+    sub = parser.add_subparsers(dest="cmd")
+
+    sub.add_parser("list")
+
+    create_p = sub.add_parser("create")
+    create_p.add_argument("name")
+
+    del_p = sub.add_parser("delete")
+    del_p.add_argument("name")
+
+    args = parser.parse_args()
+    if args.cmd == "list":
+        for name in list_campaigns():
+            print(name)
+    elif args.cmd == "create":
+        CampaignManager(args.name)
+        print(f"Created campaign {args.name}")
+    elif args.cmd == "delete":
+        if delete_campaign(args.name):
+            print(f"Deleted campaign {args.name}")
+        else:
+            print("Campaign not found")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/config.py
+++ b/config.py
@@ -9,6 +9,8 @@ class Config:
 
     chat_model: str = "gpt-3.5-turbo"
     system_prompt: str = ""
+    temperature: float = 0.7
+    max_tokens: int = 256
 
 
 def load_config(path: str = "config.json") -> Config:
@@ -22,9 +24,9 @@ def load_config(path: str = "config.json") -> Config:
         except Exception:
             pass
     cfg.chat_model = os.getenv("CHAT_MODEL", data.get("chat_model", cfg.chat_model))
-    cfg.system_prompt = os.getenv(
-        "SYSTEM_PROMPT", data.get("system_prompt", cfg.system_prompt)
-    )
+    cfg.system_prompt = os.getenv("SYSTEM_PROMPT", data.get("system_prompt", cfg.system_prompt))
+    cfg.temperature = float(os.getenv("TEMPERATURE", data.get("temperature", cfg.temperature)))
+    cfg.max_tokens = int(os.getenv("MAX_TOKENS", data.get("max_tokens", cfg.max_tokens)))
     return cfg
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit>=1.25
 openai>=0.27
+duckduckgo-search>=2.9

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -46,6 +46,8 @@ def get_response(prompt: str) -> str:
         resp = openai.ChatCompletion.create(
             model=CONFIG.chat_model,
             messages=messages,
+            temperature=CONFIG.temperature,
+            max_tokens=CONFIG.max_tokens,
         )
         return resp.choices[0].message["content"].strip()
     except Exception as e:  # pragma: no cover - depends on external API

--- a/tests/test_arc_manager.py
+++ b/tests/test_arc_manager.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+import sys
+import BlackFeather.campaign_manager as campaign_manager
+sys.modules.setdefault("campaign_manager", campaign_manager)
+import BlackFeather.world_memory as world_memory
+sys.modules.setdefault("world_memory", world_memory)
+import BlackFeather.arc_manager as arc_module
+sys.modules.setdefault("arc_manager", arc_module)
+from BlackFeather.arc_manager import ArcManager
+
+
+def _setup(tmp_path, monkeypatch):
+    monkeypatch.setattr(campaign_manager, "CAMPAIGNS_DIR", tmp_path)
+    monkeypatch.setattr(world_memory, "CAMPAIGNS_DIR", tmp_path)
+    real_am = arc_module.ArcManager
+    monkeypatch.setattr(arc_module, "ArcManager", lambda *a, **k: None)
+    try:
+        instance = real_am("ArcTest")
+    finally:
+        monkeypatch.setattr(arc_module, "ArcManager", real_am)
+    return instance
+
+
+def test_arc_manager_creates_villain(tmp_path, monkeypatch):
+    am = _setup(tmp_path, monkeypatch)
+    dm_file = Path(tmp_path) / "ArcTest" / "world_memory_dm.json"
+    data = json.loads(dm_file.read_text())
+    assert len(data) == 1
+    villain = next(iter(data.values()))
+    assert villain["type"] == "villain"
+
+
+def test_progress_villain_logs_event(tmp_path, monkeypatch):
+    am = _setup(tmp_path, monkeypatch)
+    am.progress_villain("steals the gem")
+    dm_file = Path(tmp_path) / "ArcTest" / "world_memory_dm.json"
+    data = json.loads(dm_file.read_text())
+    villain = next(iter(data.values()))
+    assert "steals the gem" in villain["description"]
+    events = json.loads((Path(tmp_path) / "ArcTest" / "events_dm_log.json").read_text())
+    assert any("steals the gem" in e["description"] for e in events.values())

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,20 @@
+from BlackFeather import prompt_builder as pb
+
+
+def test_summarize_player_basic():
+    summary = pb.summarize_player({"name": "Lia", "race": "elf", "character_class": "wizard", "level": 3})
+    assert "Lia is a level 3 elf wizard" in summary
+
+
+def test_build_prompt_sections():
+    prompt = pb.build_prompt(
+        "Lia",
+        {"name": "Lia", "race": "elf", "character_class": "wizard", "level": 3},
+        {"quests": {"active": {}, "completed": {}, "missed": {}}, "npcs": {}, "items": {}, "events": {}},
+        [],
+        ["Hello"],
+        "What now?",
+    )
+    assert "### Player Info" in prompt
+    assert "### Campaign" in prompt
+    assert "Player: What now?" in prompt


### PR DESCRIPTION
## Summary
- add duckduckgo search helper
- expose new temperature and max_tokens config settings
- support config options in the Streamlit app
- provide a small CLI for campaign management
- document configuration and command-line usage
- update future roadmap
- add unit tests for `ArcManager` and `prompt_builder`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bad7d49ec8322abedffec308c75de